### PR TITLE
Allow calling `AddressFinder.verification` under Ruby 3

### DIFF
--- a/lib/addressfinder.rb
+++ b/lib/addressfinder.rb
@@ -30,14 +30,14 @@ module AddressFinder
     end
 
     def cleanse(args={}) # We are keeping this method for backward compatibility
-      AddressFinder::Verification.new(args.merge(http: AddressFinder::HTTP.new(configuration))).perform.result
+      AddressFinder::Verification.new(**args.merge(http: AddressFinder::HTTP.new(configuration))).perform.result
     end
 
     def verification(args={})
       if (args[:country] || configuration.default_country) == 'au' && configuration.verification_version&.downcase == "v2"
-        AddressFinder::V2::Au::Verification.new(args.merge(http: AddressFinder::HTTP.new(configuration))).perform.result
+        AddressFinder::V2::Au::Verification.new(**args.merge(http: AddressFinder::HTTP.new(configuration))).perform.result
       else
-        AddressFinder::Verification.new(args.merge(http: AddressFinder::HTTP.new(configuration))).perform.result
+        AddressFinder::Verification.new(**args.merge(http: AddressFinder::HTTP.new(configuration))).perform.result
       end
     end
 

--- a/spec/lib/addressfinder_spec.rb
+++ b/spec/lib/addressfinder_spec.rb
@@ -29,12 +29,22 @@ RSpec.describe AddressFinder do
         expect(AddressFinder::Verification).to receive_message_chain(:new, :perform, :result)
         subject
       end
+
+      it "safely passes arguments through" do
+        stub_request(:get, Addressable::Template.new("https://api.addressfinder.io/api/nz/address/verification{?args*}")).to_return(:status => 200, :body => "{}", :headers => {})
+        subject
+      end
     end
 
     context "with country set to au" do
       let(:args){ {country: "au", q: "12 high street sydney"} }
       it "calls the v2::Au class" do
         expect(AddressFinder::V2::Au::Verification).to receive_message_chain(:new, :perform, :result)
+        subject
+      end
+
+      it "safely passes arguments through" do
+        stub_request(:get, Addressable::Template.new("https://api.addressfinder.io/api/au/address/v2/verification{?args*}")).to_return(:status => 200, :body => "{}", :headers => {})
         subject
       end
     end


### PR DESCRIPTION
### Background
It turns out that `AddressFinder.verification` still calls into the relevant concrete verification object with `new(args.merge(...))`, but that initialiser takes keyword args, and so under Ruby 3.0+ we see an error.

Early in the 2.7 series this would have been relatively obvious, but since Ruby 2.7.2, this warning is silenced by default.

**Approach**
This PR simply applies the `**` operator to those callsites (and, opportunistically, in `.cleanse`), corresponding to the approach in #27.

