### PR TITLE
Resolve load warnings on Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,3 +25,19 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: ruby integration_tests/loader.rb

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
 
     steps:
     - uses: actions/checkout@v3

--- a/addressfinder.gemspec
+++ b/addressfinder.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7'
   gem.add_dependency 'multi_json', '~> 1.15'
   gem.add_dependency "concurrent-ruby", "~> 1.2"
+  gem.add_dependency 'ostruct', '> 0.6'
 
   gem.add_development_dependency 'guard-rspec', '~> 4.7'
   gem.add_development_dependency 'listen', '~> 3.7'

--- a/integration_tests/loader.rb
+++ b/integration_tests/loader.rb
@@ -1,0 +1,12 @@
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  gem "warning"
+  gem "addressfinder", path: File.expand_path("../..", __dir__), require: false
+end
+
+Warning.process { :raise }
+
+require 'addressfinder'


### PR DESCRIPTION
Under Ruby 3.4, loading `addressfinder` causes a warning of the form
> warning: [...]/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.

This changes addresses that by explicitly depending on `ostruct` (arbitrarily from v0.6), and installing an integration test that tries to ensure that the gem loads warning-free (which is complicated by the fact that the existing development dependencies depend on `ostruct` themselves).
