### PR TITLE
Only enforce ssl on port 443 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (September 2025) #
+
+* Don't enforce ssl as part of Net::HTTP configuration
+
 # Addressfinder 1.15.0 (March 2025) #
 
 * Automatically skip empty strings within Batch verification

--- a/lib/addressfinder/http.rb
+++ b/lib/addressfinder/http.rb
@@ -64,7 +64,7 @@ module AddressFinder
                              config.proxy_password)
         http.open_timeout = config.timeout
         http.read_timeout = config.timeout
-        http.use_ssl = true
+        http.use_ssl = config.port == 443
         http
       end
     end


### PR DESCRIPTION
Let us use the gem locally without needing a proxy or ssl setup